### PR TITLE
Fix calling executeSql with a wrong argument

### DIFF
--- a/src/scripts/base.js
+++ b/src/scripts/base.js
@@ -209,7 +209,7 @@ function delSetting(name) {
 
 // Creates the pages table in the database if it does not already exist.
 function initializeStorage(callback) {
-  executeSql(DATABASE_STRUCTURE, $.noop, callback);
+  executeSql(DATABASE_STRUCTURE, [], callback);
 }
 
 // Executes the specified SQL query with the specified arguments within a


### PR DESCRIPTION
Otherwise this blows up and the extension doesn't work in newer Chromes.